### PR TITLE
Treat raw as an embedded language instead of a string

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,10 @@
       {
         "language": "poryscript",
         "scopeName": "source.pory",
-        "path": "./syntaxes/poryscript.tmLanguage.json"
+        "path": "./syntaxes/poryscript.tmLanguage.json",
+        "embeddedLanguages": {
+          "source.arm": "arm"
+        }
       }
     ],
     "configuration": {

--- a/syntaxes/poryscript.tmLanguage.json
+++ b/syntaxes/poryscript.tmLanguage.json
@@ -76,9 +76,14 @@
 		"sections": {
 			"patterns": [
 				{
-					"name": "string.other.pory",
+					"name": "source.arm.embedded.pory",
 					"begin": "`",
-					"end": "`"
+					"end": "`",
+					"patterns": [
+						{
+							"include": "source.arm"
+						}
+					]
 				}
 			]
 		},


### PR DESCRIPTION
Even if Poryscript treats the contents of the `raw` directive as a big blob to output doesn't mean the syntax highlighter should. This change makes the contents of the `raw` directive act as an embedded `arm` language. The user can then install a syntax highlighter for the `arm` language (I personally use Dan Underwood's extension) and it'll highlight the raw section using the external syntax highlighter.

![image](https://user-images.githubusercontent.com/794812/68250602-3e5c1700-ffef-11e9-9316-0cf3fcf17128.png)
