### PR TITLE
Implement highlighting for script.inc and text.inc

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -39,7 +39,7 @@ export function activate(context: ExtensionContext) {
 	// Options to control the language client
 	let clientOptions: LanguageClientOptions = {
 		// Register the server for poryscript documents
-		documentSelector: [{ scheme: 'file', language: 'poryscript' }],
+		documentSelector: [{ scheme: 'file', language: 'poryscript' }, {scheme: 'file', language: 'poryscript-asm'}],
 		synchronize: {
 			// Notify the server about file changes to *.inc, *.pory, *.h files contained in the workspace
 			fileEvents: [workspace.createFileSystemWatcher('**/*.inc'), workspace.createFileSystemWatcher('**/*.pory'), workspace.createFileSystemWatcher('**/*.h')]

--- a/package.json
+++ b/package.json
@@ -32,6 +32,18 @@
           ".pory"
         ],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "poryscript-asm",
+        "aliases": [
+          "Poryasm",
+          "poryasm"
+        ],
+				"filenames": [
+					"text.inc",
+					"scripts.inc"
+				],
+        "configuration": "./language-configuration.json"
       }
     ],
     "grammars": [
@@ -42,7 +54,16 @@
         "embeddedLanguages": {
           "source.arm": "arm"
         }
-      }
+      },
+      {
+				"language": "poryscript-asm",
+				"scopeName": "source.pory.asm",
+				"path": "./syntaxes/poryscript-asm.tmLanguage.json",
+				"embeddedLanguages": {
+					"source.arm": "arm",
+					"source.pory": "poryscript"
+				}
+			}
     ],
     "configuration": {
       "type": "object",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "onLanguage:poryscript"
+    "onLanguage:poryscript",
+    "onLanguage:poryscript-asm"
   ],
   "main": "./client/out/extension",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
           "Poryasm",
           "poryasm"
         ],
-				"filenames": [
-					"text.inc",
-					"scripts.inc"
-				],
+        "filenames": [
+          "text.inc",
+          "scripts.inc"
+        ],
         "configuration": "./language-configuration.json"
       }
     ],
@@ -57,14 +57,14 @@
         }
       },
       {
-				"language": "poryscript-asm",
-				"scopeName": "source.pory.asm",
-				"path": "./syntaxes/poryscript-asm.tmLanguage.json",
-				"embeddedLanguages": {
-					"source.arm": "arm",
-					"source.pory": "poryscript"
-				}
-			}
+        "language": "poryscript-asm",
+        "scopeName": "source.pory.asm",
+        "path": "./syntaxes/poryscript-asm.tmLanguage.json",
+        "embeddedLanguages": {
+          "source.arm": "arm",
+          "source.pory": "poryscript"
+        }
+      }
     ],
     "configuration": {
       "type": "object",

--- a/syntaxes/poryscript-asm.tmLanguage.json
+++ b/syntaxes/poryscript-asm.tmLanguage.json
@@ -13,7 +13,7 @@
 
 		"string": {
 			"name": "string.quoted.double.pory",
-			"begin": "\"",
+			"begin": "(?<=.string )\"",
 			"end": "\"",
 			"patterns": [
 				{

--- a/syntaxes/poryscript-asm.tmLanguage.json
+++ b/syntaxes/poryscript-asm.tmLanguage.json
@@ -3,22 +3,30 @@
 	"name": "Poryscript-asm",
 	"patterns": [
 		{
-			"include": "#poryasm"
+			"include": "#string"
+		},
+		{
+			"include": "source.arm"
 		}
 	],
 	"repository": {
-		"poryasm": {
+
+		"string": {
+			"name": "string.quoted.double.pory",
+			"begin": "\"",
+			"end": "\"",
 			"patterns": [
 				{
-					"name": "source.arm.embedded.pory",
-					"patterns": [
-						{
-							"include": "source.pory"
-						},
-						{
-							"include": "source.arm"
-						}
-					]
+					"name": "constant.character.escape.pory.asm",
+					"match": "\\\\."
+				},
+				{
+					"name": "constant.character.escape.pory.asm",
+					"match": "{[\\w ]+}"
+				},
+				{
+					"name": "constant.character.escape.pory.asm",
+					"match": "\\$"
 				}
 			]
 		}

--- a/syntaxes/poryscript-asm.tmLanguage.json
+++ b/syntaxes/poryscript-asm.tmLanguage.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "Poryscript-asm",
+	"patterns": [
+		{
+			"include": "#poryasm"
+		}
+	],
+	"repository": {
+		"poryasm": {
+			"patterns": [
+				{
+					"name": "source.arm.embedded.pory",
+					"patterns": [
+						{
+							"include": "source.pory"
+						},
+						{
+							"include": "source.arm"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "source.pory.asm"
+}

--- a/syntaxes/poryscript.tmLanguage.json
+++ b/syntaxes/poryscript.tmLanguage.json
@@ -177,6 +177,25 @@
 					},
 					"patterns": [
 						{
+							"name": "string.quoted.double.pory",
+							"begin": "\"",
+							"end": "\"",
+							"patterns": [
+								{
+									"name": "constant.character.escape.pory",
+									"match": "\\\\."
+								},
+								{
+									"name": "constant.character.escape.pory",
+									"match": "{[\\w ]+}"
+								},
+								{
+									"name": "constant.character.escape.pory",
+									"match": "\\$"
+								}
+							]
+						},
+						{
 							"include": "source.arm"
 						}
 					]

--- a/syntaxes/poryscript.tmLanguage.json
+++ b/syntaxes/poryscript.tmLanguage.json
@@ -178,7 +178,7 @@
 					"patterns": [
 						{
 							"name": "string.quoted.double.pory",
-							"begin": "\"",
+							"begin": "(?<=.string )\"",
 							"end": "\"",
 							"patterns": [
 								{


### PR DESCRIPTION
When using Poryscript, any section of asm included as `raw` will have really clear highlighting based on a combination of an arm grammar and the Poryscript language server.

However, when working with base pret repos, all existing maps will have their scripts in `scripts.inc` and `text.inc`. These do not highlight correctly when using the Poryscript grammar as it doesn't correctly overlay the arm grammar, and when using the arm grammar you don't get the benefits of the Poryscript language server.

I don't have a particularly good knowledge of TextMate grammars, and was unable to find a way to match content based on filename in a language.json so that if it was `scripts.inc` or `text.inc` it would designate the whole file as raw.  Because of this, I had to implement a secondary language that inherits the arm grammar for the whole file while also loading the language server. 

I don't know if there is a better approach than what I have implemented, but functionally it gives great results with clear syntax highlighting for the base pokemon scripts.

![image](https://user-images.githubusercontent.com/386846/138094048-215a473c-559b-4873-bb36-456f1d467d98.png)

I've also added an improvement to syntax in the `raw` blocks as well as for `scripts.inc` and `text.inc` that will highlight escapes for text strings. 

This seems to work fine in my testing, though I'd appreciate it being checked. I'm a bit out of my depth here, and this was all done by prodding at things. Names etc may not be ideal, and there might be a cleaner way than having to implement a whole second language.